### PR TITLE
Fix schema name

### DIFF
--- a/app/scripts/inject/levelup.forms.ts
+++ b/app/scripts/inject/levelup.forms.ts
@@ -39,21 +39,23 @@ export class Forms {
     };
 
     this.utility.Xrm.Page.ui.controls.forEach((c: Xrm.Page.StandardControl) => {
-      let controlName = c.getName(),
-        controlType = c.getControlType(),
-        controlNode =
-          this.utility.formDocument.getElementById(controlName) ||
-          this.utility.formDocument.querySelector(`label[id$="${controlName}-field-label"]`);
-      if (!controlNode) {
-        return;
-      }
+      let controlName = c.getName();
       if (!c.getAttribute) {
         createSchemaNameInput(controlName, this.utility.formDocument.getElementById(`${controlName}_d`));
       } else {
+        let attributeName = c.getAttribute().getName(),
+        controlNode =
+          this.utility.formDocument.getElementById(controlName) ||
+          this.utility.formDocument.querySelector(`div[data-control-name="${controlName}"]`)
+                                   .querySelector(`label[id$="${attributeName}-field-label"]`) ||
+          this.utility.formDocument.querySelector(`label[id$="${controlName}-field-label"]`);
+        if (!controlNode) {
+          return;
+        }
         if (!c.getVisible()) {
           return;
         }
-        createSchemaNameInput(c.getAttribute().getName(), controlNode);
+        createSchemaNameInput(attributeName, controlNode);
       }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16910,7 +16910,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -17064,7 +17065,8 @@
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
         "camelcase": "^3.0.0"


### PR DESCRIPTION
Fixes schema name when there are multiple controls of the same column on the form (or better when the control name does not match the column name)

fixes #153 