### PR TITLE
Update levelup.forms.ts

### DIFF
--- a/app/scripts/inject/levelup.forms.ts
+++ b/app/scripts/inject/levelup.forms.ts
@@ -385,9 +385,9 @@ export class Forms {
                 workflowKeyValue = workflowKeyValue === 0 || workflowKeyValue.Value === 0 ? 'Background' : 'Real-time';
               } else if (keyName === 'runas') {
                 workflowKeyValue =
-                  workflowKeyValue === 0 || workflowKeyValue.Value === 0
+                  workflowKeyValue === 0 || workflowKeyValue?.Value === 0
                     ? 'Owner'
-                    : workflowKeyValue === 1 || workflowKeyValue.Value === 1
+                    : workflowKeyValue === 1 || workflowKeyValue?.Value === 1
                     ? 'User'
                     : '';
               } else if (keyName === 'ismanaged') {


### PR DESCRIPTION
fix for null runas
Some older systems have background workflows where the runas attribute is null, this blows up the script and breaks the "Processes and Business Rules" functionality