### PR TITLE
Improved the Accessibility of the tool

### DIFF
--- a/app/pages/options.html
+++ b/app/pages/options.html
@@ -107,7 +107,7 @@
                     <div class="mdl-grid">
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="displayLogicalNames" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">settings_applications</i>
+                                <i class="material-icons" aria-hidden="true">settings_applications</i>
                                 <span>Logical Names</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="displayLogicalNames">
@@ -116,7 +116,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="clearLogicalNames" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">clear</i>
+                                <i class="material-icons" aria-hidden="true">clear</i>
                                 <span>Clear Logical names</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="clearLogicalNames">
@@ -125,7 +125,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="blurFields" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">blur_on</i>
+                                <i class="material-icons" aria-hidden="true">blur_on</i>
                                 <span>Blur Fields</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="blurFields">
@@ -134,7 +134,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="resetBlur" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">blur_off</i>
+                                <i class="material-icons" aria-hidden="true">blur_off</i>
                                 <span>Reset Blur</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="resetBlur">
@@ -143,7 +143,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" data-category="Forms" id="godMode" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">vpn_key</i>
+                                <i class="material-icons" aria-hidden="true">vpn_key</i>
                                 <span>God Mode</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="godMode">
@@ -152,7 +152,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="allFields" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">list</i>
+                                <i class="material-icons" aria-hidden="true">list</i>
                                 <span>All Fields</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="allFields">
@@ -161,7 +161,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="highlightDirtyFields" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">warning</i>
+                                <i class="material-icons" aria-hidden="true">warning</i>
                                 <span>Changed fields</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="highlightDirtyFields">
@@ -170,7 +170,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="copyRecordUrl" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">open_in_new</i>
+                                <i class="material-icons" aria-hidden="true">open_in_new</i>
                                 <span>Record URL</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="copyRecordUrl">
@@ -179,7 +179,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="copyRecordId" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">info</i>
+                                <i class="material-icons" aria-hidden="true">info</i>
                                 <span>Record Id</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="copyRecordId">
@@ -188,7 +188,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" data-category="Forms" id="openRecordWebApi" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">open_in_browser</i>
+                                <i class="material-icons" aria-hidden="true">open_in_browser</i>
                                 <span>Open Record in Web API</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openRecordWebApi">
@@ -197,7 +197,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="refreshAllSubgrids" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">refresh</i>
+                                <i class="material-icons" aria-hidden="true">refresh</i>
                                 <span>Refresh all subgrids</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="refreshAllSubgrids">
@@ -206,7 +206,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" data-category="Forms" id="populateMin" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">chevron_left</i>
+                                <i class="material-icons" aria-hidden="true">chevron_left</i>
                                 <span>Minimum values</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="populateMin">
@@ -215,7 +215,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" data-category="optionsets" id="optionSets" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">unfold_more</i>
+                                <i class="material-icons" aria-hidden="true">unfold_more</i>
                                 <span>Show Optionset values</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="optionSets">
@@ -224,7 +224,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="cloneRecord" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">group_add</i>
+                                <i class="material-icons" aria-hidden="true">group_add</i>
                                 <span>Clone record</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="cloneRecord">
@@ -233,7 +233,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="refresh" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">sync_disabled</i>
+                                <i class="material-icons" aria-hidden="true">sync_disabled</i>
                                 <span>Refresh + Autosave off</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="refresh">
@@ -242,7 +242,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="toggleTabs" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">toggle_on</i>
+                                <i class="material-icons" aria-hidden="true">toggle_on</i>
                                 <span>Toggle Tabs</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="toggleTabs">
@@ -251,7 +251,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" data-category="workflows" id="workflows" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">view_module</i>
+                                <i class="material-icons" aria-hidden="true">view_module</i>
                                 <span>Processes &amp; Business Rules</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="workflows">
@@ -260,7 +260,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Forms" id="formProperties" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                            <i class="material-icons">apps</i>
+                            <i class="material-icons" aria-hidden="true">apps</i>
                             <span>Record Properties</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="formProperties">
@@ -275,7 +275,7 @@
                     <div class="mdl-grid">
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openRecord" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">launch</i>
+                                <i class="material-icons" aria-hidden="true">launch</i>
                                 <span>Open record by Id</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openRecord">
@@ -284,7 +284,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="newRecord" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">add_circle</i>
+                                <i class="material-icons" aria-hidden="true">add_circle</i>
                                 <span>New record</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="newRecord">
@@ -293,7 +293,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openList" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">list_alt</i>
+                                <i class="material-icons" aria-hidden="true">list_alt</i>
                                 <span>Open List</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openList">
@@ -302,7 +302,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openSecurity" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">security</i>
+                                <i class="material-icons" aria-hidden="true">security</i>
                                 <span>Security</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openSecurity">
@@ -311,7 +311,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openSystemJobs" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">schedule</i>
+                                <i class="material-icons" aria-hidden="true">schedule</i>
                                 <span>System Jobs</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openSystemJobs">
@@ -320,7 +320,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openSolutions" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">view_list</i>
+                                <i class="material-icons" aria-hidden="true">view_list</i>
                                 <span>Solutions</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openSolutions">
@@ -329,7 +329,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openProcesses" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">list</i>
+                                <i class="material-icons" aria-hidden="true">list</i>
                                 <span>Processes</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openProcesses">
@@ -338,7 +338,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openMailboxes" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">email</i>
+                                <i class="material-icons" aria-hidden="true">email</i>
                                 <span>Mailboxes</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openMailboxes">
@@ -347,7 +347,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openMain" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">home</i>
+                                <i class="material-icons" aria-hidden="true">home</i>
                                 <span>Open Main</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openMain">
@@ -356,7 +356,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openAdvFind" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">search</i>
+                                <i class="material-icons" aria-hidden="true">search</i>
                                 <span>Advanced Find</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openAdvFind">
@@ -365,7 +365,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="mocaClient" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">mobile_screen_share</i>
+                                <i class="material-icons" aria-hidden="true">mobile_screen_share</i>
                                 <span>Mobile Client</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="mocaClient">
@@ -374,7 +374,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="diagnostics" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">developer_board</i>
+                                <i class="material-icons" aria-hidden="true">developer_board</i>
                                 <span>Performance Diag</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="diagnostics">
@@ -383,7 +383,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="perfCenter" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">developer_board</i>
+                                <i class="material-icons" aria-hidden="true">developer_board</i>
                                 <span>Performance Center</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="perfCenter">
@@ -392,7 +392,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="instancePicker" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">view_carousel</i>
+                                <i class="material-icons" aria-hidden="true">view_carousel</i>
                                 <span>Instance Picker</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="instancePicker">
@@ -401,7 +401,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="openPPAC" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">build</i>
+                                <i class="material-icons" aria-hidden="true">build</i>
                                 <span>Power Platform Admin</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openPPAC">
@@ -410,7 +410,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Navigation" id="solutionHistory" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">watch_later</i>
+                                <i class="material-icons" aria-hidden="true">watch_later</i>
                                 <span>Solutions History</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="solutionHistory">
@@ -425,7 +425,7 @@
                     <div class="mdl-grid">
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Grid" id="openGrid" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">launch</i>
+                                <i class="material-icons" aria-hidden="true">launch</i>
                                 <span>New window</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="openGrid">
@@ -434,7 +434,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Grid" data-category="quickFindFields" id="quickFindFields" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">more_horiz</i>
+                                <i class="material-icons" aria-hidden="true">more_horiz</i>
                                 <span>Quick Find fields</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="quickFindFields">
@@ -443,7 +443,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Grid" id="blurView" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">blur_on</i>
+                                <i class="material-icons" aria-hidden="true">blur_on</i>
                                 <span>Blur Fields</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="blurView">
@@ -452,7 +452,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Grid" id="resetViewBlur" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">blur_off</i>
+                                <i class="material-icons" aria-hidden="true">blur_off</i>
                                 <span>Reset Blur</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="resetViewBlur">
@@ -461,7 +461,7 @@
                         </div>
                         <div class="mdl-cell mdl-cell--4-col">
                             <button data-category="Grid" data-category="sendToFXB" id="sendToFXB" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                                <i class="material-icons">code</i>
+                                <i class="material-icons" aria-hidden="true">code</i>
                                 <span>Open View in FetchXML Builder</span>
                             </button>
                             <div class="mdl-tooltip" data-mdl-for="sendToFXB">
@@ -485,15 +485,15 @@
                         </div>
                         <div class="mdl-cell mdl-cell--8-col impersonization-rows">
                             <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent reset" id="searchUserButton">
-                                <i class="material-icons">search_user</i>
+                                <i class="material-icons" aria-hidden="true">search_user</i>
                                 <span>Search User</span>
                             </button>
                             <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent reset" id="startImpersonationButton" disabled>
-                                <i class="material-icons">badge</i>
+                                <i class="material-icons" aria-hidden="true">badge</i>
                                 <span>Impersonate</span>
                             </button>
                             <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent reset" id="resetImpersonationButton">
-                                <i class="material-icons">refresh</i>
+                                <i class="material-icons" aria-hidden="true">refresh</i>
                                 <span>Reset</span>
                             </button>
                             <datalist id="userList">

--- a/app/pages/options.html
+++ b/app/pages/options.html
@@ -75,8 +75,14 @@
                 <div class="mdl-layout-spacer"></div>
                 <!-- Navigation. We hide it in small screens. -->
                 <nav class="mdl-navigation">
-                    <a rel="noopener" target="_blank" class="mdl-navigation__link" href="https://github.com/rajyraman/Levelup-for-Dynamics-CRM/blob/master/README.md">Help</a>
-                    <a target="_blank" class="mdl-navigation__link" id="issueUrl">Report Issue</a>
+                    <a rel="noopener" target="_blank" class="mdl-navigation__link" href="https://github.com/rajyraman/Levelup-for-Dynamics-CRM/blob/master/README.md">
+                        Help
+                        <span aria-label="This will navigate to another tab"></span>
+                    </a>
+                    <a target="_blank" class="mdl-navigation__link" id="issueUrl">
+                        Report Issue
+                        <span aria-label="This will navigate to another tab"></span>
+                    </a>
                 </nav>
             </div>
             <!-- Tabs -->

--- a/app/pages/options.html
+++ b/app/pages/options.html
@@ -507,6 +507,7 @@
     </div>
     <link rel="stylesheet" href="../styles/material-icons.min.css">
     <link rel="stylesheet" href="../styles/material.min.css">
+    <link rel="stylesheet" href="../styles/app-styles.css">
     <script src="../scripts/options.js"></script>
     <script defer src="../scripts/material.min.js"></script>
 </body>

--- a/app/scripts/options.ts
+++ b/app/scripts/options.ts
@@ -8,7 +8,7 @@ window.addEventListener('DOMContentLoaded', function () {
   if (drawerButton) {
     drawerButton.title = "Admin Area";
 
-    let drawerButtonIcon = document.querySelector(".mdl-layout__drawer-button") as HTMLElement;
+    let drawerButtonIcon = drawerButton.querySelector("i") as HTMLElement;
     drawerButtonIcon?.setAttribute("aria-hidden", true);
   }
 

--- a/app/scripts/options.ts
+++ b/app/scripts/options.ts
@@ -4,6 +4,14 @@ window.addEventListener('DOMContentLoaded', function () {
   const extensionVersion = chrome.runtime.getManifest().version;
   document.getElementById('version').innerHTML = `v${extensionVersion}`;
 
+  let drawerButton = document.querySelector(".mdl-layout__drawer-button") as HTMLElement;
+  if (drawerButton) {
+    drawerButton.title = "Admin Area";
+
+    let drawerButtonIcon = document.querySelector(".mdl-layout__drawer-button") as HTMLElement;
+    drawerButtonIcon?.setAttribute("aria-hidden", true);
+  }
+
   const bodyText = encodeURIComponent(`
     Browser Version: ${navigator}
     Extension Version: ${extensionVersion}

--- a/app/scripts/options.ts
+++ b/app/scripts/options.ts
@@ -12,6 +12,18 @@ window.addEventListener('DOMContentLoaded', function () {
     drawerButtonIcon?.setAttribute("aria-hidden", true);
   }
 
+  let optionButtons = document.querySelectorAll(".mdl-button");
+  if (optionButtons.length > 0) {
+    for(let i = 0; i < optionButtons.length; i++) {
+      let oButton = optionButtons[i] as HTMLButtonElement;
+      let tooltip = oButton?.parentElement?.querySelector(".mdl-tooltip");
+      if (tooltip && oButton.id?.length > 0) {
+        tooltip.id = oButton.id + "-tooltip";
+        oButton?.setAttribute("aria-describedby", tooltip.id);
+      }
+    }
+  }
+
   const bodyText = encodeURIComponent(`
     Browser Version: ${navigator}
     Extension Version: ${extensionVersion}

--- a/app/styles/app-styles.css
+++ b/app/styles/app-styles.css
@@ -10,3 +10,15 @@
 a.mdl-navigation__link {
     text-decoration: underline;
 }
+
+.mdl-button--raised:active {
+    background: black;
+}
+
+.mdl-button--raised:focus {
+    background: black;
+}
+
+.mdl-button--raised:hover {
+    background: black;
+}

--- a/app/styles/app-styles.css
+++ b/app/styles/app-styles.css
@@ -1,0 +1,3 @@
+.mdl-textfield__label {
+    color:black
+}

--- a/app/styles/app-styles.css
+++ b/app/styles/app-styles.css
@@ -6,3 +6,7 @@
     background-color: rgb(0,78,140);
     border: 1px solid black;
 }
+
+a.mdl-navigation__link {
+    text-decoration: underline;
+}

--- a/app/styles/app-styles.css
+++ b/app/styles/app-styles.css
@@ -1,3 +1,8 @@
 .mdl-textfield__label {
     color:black
 }
+
+.mdl-layout__tab.is-active {
+    background-color: rgb(0,78,140);
+    border: 1px solid black;
+}


### PR DESCRIPTION
Hey there, 

Our company recently had an accessibility audit done on tools that are currently in use, and LevelUp came back with a few faults. The issues were pretty quick to resolve, so I figured I would write some fixes and submit them in hopes that we could get them added into the extension. 

Within this pull request contains all of the enhancements identified:
* Adding aria-hidden to all the Icons so that a Screen reader doesn't attempt to read them out
* Adding aria-describedby to all of the buttons so that their tooltips are properly read out by screen readers
* Added underlines to the links in the top-right corner to make them visually identifiable as links
* Fixed a colour contrast issue inside of the "Impersonate" tab to make it WCAG complaint
* Added a background colour to the Buttons so that a user who is using their keyboard can visually identify at a glance when a button is selected (the current buttons have a drop-shadow, however users with a visual impairment would find it hard to see) 
* Added an aria-label to the Drawer Button in the top-left corner so that a Screen Reader would read out "Admin Area" instead of just "button"
